### PR TITLE
Changed all references to Devore to equiv secs in Devore and Berk

### DIFF
--- a/paried_t_tests.md
+++ b/paried_t_tests.md
@@ -1,5 +1,5 @@
-# Devore: Probability and Statistics for Engineering and the Sciences
+# Devore & Berk: Modern Mathematical Statistics with Applications
 
-Please read section 9.3 in *Devore*. 
+Please read section 10.3 in [*Devore & Berk*](https://link-springer-com.libproxy.berkeley.edu/book/10.1007%2F978-1-4614-0391-3). 
 
-- The section is titled **paired t-Tests**. 
+- The section is titled **Analysis of Paired Data**. 

--- a/rank_sum_test.md
+++ b/rank_sum_test.md
@@ -1,5 +1,5 @@
-# Devore: Probability and Statistics for Engineering and the Sciences# Wilcoxon Rank Sum Test 
+# Devore & Berk: Modern Mathematical Statistics with Applications
 
-Read section 15.2 in *Devore*. 
+Read section 14.2 in [*Devore & Berk*](https://link-springer-com.libproxy.berkeley.edu/book/10.1007%2F978-1-4614-0391-3). 
 
 - This section is called **The Wilcoxon Rank-Sum Test**

--- a/two_sample_tests.md
+++ b/two_sample_tests.md
@@ -1,6 +1,5 @@
-# Devore: Probability and Statistics for Engineering and the Sciences
+# Devore & Berk: Modern Mathematical Statistics with Applications
 
-Please read section 9.1 and 9.2 in *Devore* (that is the name of the
-author). 
+Please read section 10.1 and 10.2 in [*Devore & Berk*](https://link-springer-com.libproxy.berkeley.edu/book/10.1007%2F978-1-4614-0391-3)
 
-- Stop reading when you get to *pooled t-procedures*. 
+- Stop reading when you get to *Pooled t Procedures*. 

--- a/wilcox_rank_sum_test.md
+++ b/wilcox_rank_sum_test.md
@@ -1,4 +1,4 @@
-# Devore: Modern Mathematical Statistics
+# Devore & Berk: Modern Mathematical Statistics with Applications
 
-- Please read section 14.2, "The Wilcox Rank-Sum Test", in _Modern Mathematical Statistics_.  
-- A PDF of this chapter is available [in the reading repository](https://github.com/mids-w203/reading/blob/master/docs/devore_modern_math_stats_chapter_12.pdf), and a full-text copy of the entire book is available through the [UC Berkeley Library and Springer.](https://link.springer.com/book/10.1007%2F978-1-4614-0391-3#toc) 
+- Please read section 14.2, "The Wilcox Rank-Sum Test", in _Modern Mathematical Statistics with Applications_.  
+- A PDF of this chapter is available [in the reading repository](https://github.com/mids-w203/reading/blob/master/docs/devore_modern_math_stats_chapter_12.pdf), and a full-text copy of the entire book is available through the [UC Berkeley Library and Springer.](https://link-springer-com.libproxy.berkeley.edu/book/10.1007%2F978-1-4614-0391-3) 

--- a/wilcoxon_sign_rank_test.md
+++ b/wilcoxon_sign_rank_test.md
@@ -1,4 +1,4 @@
-# Devore: _Modern Mathematical Statistics with Applications_
+# Devore & Berk: Modern Mathematical Statistics with Applications
 
 - Please read section 14.1, "The Wilcoxon Signed-Rank Test", in _Modern Mathematical Statistics with Applications_. 
-- A PDF of this chapter is available [in the reading repository](https://github.com/mids-w203/reading/blob/master/docs/devore_modern_math_stats_chapter_12.pdf), and a full-text copy of the entire book is available through the [UC Berkeley Library and Springer.](https://link.springer.com/book/10.1007%2F978-1-4614-0391-3#toc) 
+- A PDF of this chapter is available [in the reading repository](https://github.com/mids-w203/reading/blob/master/docs/devore_modern_math_stats_chapter_12.pdf), and a full-text copy of the entire book is available through the [UC Berkeley Library and Springer.](https://link-springer-com.libproxy.berkeley.edu/book/10.1007%2F978-1-4614-0391-3) 


### PR DESCRIPTION
This PR changes all references in future Async material.  The Devore readings in the current section were updated by direct commits to `master`.